### PR TITLE
Implements final switching row into player field in patience and present bias app

### DIFF
--- a/patience_staircase/models.py
+++ b/patience_staircase/models.py
@@ -90,6 +90,26 @@ class Player(BasePlayer):
         elif self.choice == 'I':
             self.participant.vars['icl_switching_row'] /= 2
 
+    # set final switching row
+    # ----------------------------------------------------------------------------------------------------------------
+    def set_final_switching_row(self):
+
+        current_round = self.subsession.round_number
+        current_choice = self.in_round(current_round).choice
+
+        # set final switching row if all choices have been completed or if "indifferent" was chosen
+        # ------------------------------------------------------------------------------------------------------------
+        if current_round == Constants.num_rounds or current_choice == 'I':
+
+            # randomly determine choice to "pay" (i.e., in which round otree fills in the switching row)
+            # --------------------------------------------------------------------------------------------------------
+            completed_choices = len(self.participant.vars['icl_time_sure_payoffs'])
+            choice_to_pay = random.randint(1, completed_choices)
+
+            # implied switching row
+            # --------------------------------------------------------------------------------------------------------
+            self.in_round(choice_to_pay).switching_row = self.participant.vars['icl_switching_row']
+
     # create function to increase part index by 1 when App changes
     # ------------------------------------------------------------------------------------------------------------------
     def update_part_index(self):

--- a/patience_staircase/pages.py
+++ b/patience_staircase/pages.py
@@ -73,6 +73,7 @@ class Decision(Page):
     def before_next_page(self):
         self.player.set_sure_payoffs()
         self.player.update_switching_row()
+        self.player.set_final_switching_row()
         if self.subsession.round_number == Constants.num_choices:
             self.player.update_part_index()
 

--- a/present_bias_staircase/models.py
+++ b/present_bias_staircase/models.py
@@ -89,6 +89,26 @@ class Player(BasePlayer):
         elif self.choice == 'I':
             self.participant.vars['icl_switching_row'] /= 2
 
+    # set final switching row
+    # ----------------------------------------------------------------------------------------------------------------
+    def set_final_switching_row(self):
+
+        current_round = self.subsession.round_number
+        current_choice = self.in_round(current_round).choice
+
+        # set final switching row if all choices have been completed or if "indifferent" was chosen
+        # ------------------------------------------------------------------------------------------------------------
+        if current_round == Constants.num_rounds or current_choice == 'I':
+
+            # randomly determine choice to "pay" (i.e., in which round otree fills in the switching row)
+            # --------------------------------------------------------------------------------------------------------
+            completed_choices = len(self.participant.vars['icl_sure_payoffs'])
+            choice_to_pay = random.randint(1, completed_choices)
+
+            # implied switching row
+            # --------------------------------------------------------------------------------------------------------
+            self.in_round(choice_to_pay).switching_row = self.participant.vars['icl_switching_row']
+
     # create function to increase part index by 1 when App changes
     # ------------------------------------------------------------------------------------------------------------------
     def update_part_index(self):

--- a/present_bias_staircase/pages.py
+++ b/present_bias_staircase/pages.py
@@ -72,6 +72,7 @@ class Decision(Page):
     def before_next_page(self):
         self.player.set_sure_payoffs()
         self.player.update_switching_row()
+        self.player.set_final_switching_row()
         if self.subsession.round_number == Constants.num_choices:
             self.player.update_part_index()
 


### PR DESCRIPTION
Fixes previously missing insertion of switching row in a randomly drawn round in both patience and present bias app